### PR TITLE
Fixed multiple time related issues

### DIFF
--- a/EndangerEd.Game/Screens/Games/BucketGameScreen.cs
+++ b/EndangerEd.Game/Screens/Games/BucketGameScreen.cs
@@ -459,7 +459,7 @@ public partial class BucketGameScreen(Question question) : MicroGameScreen(quest
         gameSessionStore.StopwatchClock.Reset();
         gameSessionStore.StopwatchClock.Start();
 
-        double duration = gameSessionStore.GetTimeLeft() * 1000 / 4;
+        double duration = gameSessionStore.GetTimePerGameScaled() / 4;
 
         Scheduler.AddDelayed(() =>
         {

--- a/EndangerEd.Game/Screens/Games/ConveyorGameScreen.cs
+++ b/EndangerEd.Game/Screens/Games/ConveyorGameScreen.cs
@@ -631,11 +631,11 @@ public partial class ConveyorGameScreen(Question question) : MicroGameScreen(que
         base.LoadComplete();
         audioPlayer.ChangeTrack("ingame.mp3");
         conveyorLoopTrack?.Start();
-        
+
         gameSessionStore.StopwatchClock.Reset();
         gameSessionStore.StopwatchClock.Start();
 
-        double duration = gameSessionStore.GetTimeLeft() * 1000 / 4;
+        double duration = gameSessionStore.GetTimePerGameScaled() / 4 - 500;
 
         // Add schedule to move the boxContainer to the bottom of the screen at the random time.
         Scheduler.AddDelayed(() =>

--- a/EndangerEd.Game/Screens/Games/TakePictureGameScreen.cs
+++ b/EndangerEd.Game/Screens/Games/TakePictureGameScreen.cs
@@ -487,12 +487,13 @@ public partial class TakePictureGameScreen(Question question) : MicroGameScreen(
     {
         base.LoadComplete();
         audioPlayer.ChangeTrack("ingame.mp3");
- 
+
         gameSessionStore.StopwatchClock.Reset();
         gameSessionStore.StopwatchClock.Start();
-        
+
         int duration = 3000 - gameSessionStore.Score.Value / 50 * 180;
-        
+        duration = Math.Clamp(duration, 1000, 3000);
+
         double nextJump = Clock.CurrentTime + duration * 4;
 
         spawnFishes(duration);
@@ -501,16 +502,16 @@ public partial class TakePictureGameScreen(Question question) : MicroGameScreen(
         Scheduler.AddDelayed(() =>
         {
             if (Clock.CurrentTime < nextJump) return;
-            
+
             duration = Math.Clamp(duration - 300, 1000, 3000);
             spawnFishes(duration);
-            
+
             nextJump = Clock.CurrentTime + duration * 4;
         }, 0, true);
     }
 
     private void spawnFishes(int duration)
-    { 
+    {
         Scheduler.AddDelayed(() =>
         {
             if (!allowMovingFish) return;

--- a/EndangerEd.Game/Stores/GameSessionStore.cs
+++ b/EndangerEd.Game/Stores/GameSessionStore.cs
@@ -49,13 +49,17 @@ public partial class GameSessionStore : CompositeDrawable
 
     public bool IsOverTime()
     {
-        return StopwatchClock.ElapsedMilliseconds >= TIME_PER_GAME;
+        return StopwatchClock.ElapsedMilliseconds >= GetTimePerGameScaled();
     }
 
     public int GetTimeLeft()
     {
-        double timeScaledToPoints = Math.Clamp(TIME_PER_GAME - this.Score.Value / 50 * 2 * 1000, 10000, 30000);
-        return (int)(timeScaledToPoints - StopwatchClock.ElapsedMilliseconds) / 1000;
+        return (int)(GetTimePerGameScaled() - StopwatchClock.ElapsedMilliseconds) / 1000;
+    }
+
+    public double GetTimePerGameScaled()
+    {
+        return Math.Clamp(TIME_PER_GAME - this.Score.Value / 50 * 2 * 1000, 10000, 30000);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed camera game jumper duration going below zero when the score is higher than 3000
- Changed how total time is gotten for conveyor game and bucket game
- Added a bit of buffer time to conveyor game to prevent unexpected parallel behavior
- Overtime check now properly uses scaled time